### PR TITLE
Disable Fill cursor when Level Editor script is disabled

### DIFF
--- a/Assets/GracesGames/2DTileMapLevelEditor/Scripts/Functionalities/FillFunctionality.cs
+++ b/Assets/GracesGames/2DTileMapLevelEditor/Scripts/Functionalities/FillFunctionality.cs
@@ -61,7 +61,7 @@ namespace GracesGames._2DTileMapLevelEditor.Scripts.Functionalities {
 		private void UpdateCursor() {
 			// Save the world point were the mouse clicked
 			Vector3 worldMousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-			if (_fillMode && _levelEditor.ValidPosition((int) worldMousePosition.x, (int) worldMousePosition.y, 0)) {
+			if (_levelEditor.GetScriptEnabled() && _fillMode && _levelEditor.ValidPosition((int) worldMousePosition.x, (int) worldMousePosition.y, 0)) {
 				// If valid position, set cursor to bucket
 				Cursor.SetCursor(_fillCursor, new Vector2(30, 25), CursorMode.Auto);
 			} else {


### PR DESCRIPTION
#### Check the following before opening the Pull Request:

Disable Fill cursor when Level Editor script is disabled, e.g. hide menu or opening file browser.

- [x] The code documentation is updated
- [x] Added label (Work in Progress or Ready for Review)
- [x] Assigned yourself
